### PR TITLE
version/3.0.1

### DIFF
--- a/force-app/main/default/classes/AsyncActionJobTest.cls
+++ b/force-app/main/default/classes/AsyncActionJobTest.cls
@@ -122,7 +122,11 @@ private class AsyncActionJobTest {
 		}
 
 		// Should keep re-enqueueing until the retries are exhausted
-		List<AsyncApexJob> asyncJobs = [SELECT Id, Status FROM AsyncApexJob WHERE JobType = 'Queueable'];
+		List<AsyncApexJob> asyncJobs = [
+			SELECT Id, Status
+			FROM AsyncApexJob
+			WHERE ApexClass.Name = :AsyncActionJob.class.getName()
+		];
 		Assert.areEqual(settings?.Retries__c, asyncJobs?.size(), 'Wrong # of jobs');
 		// Test.stopTest() will only process the first job -- unless aborted, they'll continue to run now, and throw an error
 		for (AsyncApexJob asyncJob : asyncJobs) {

--- a/force-app/main/default/classes/AsyncActionLauncherTest.cls
+++ b/force-app/main/default/classes/AsyncActionLauncherTest.cls
@@ -119,6 +119,7 @@ private class AsyncActionLauncherTest {
 			SELECT COUNT()
 			FROM AsyncApexJob
 			WHERE ApexClass.Name = :AsyncActionJob.class.getName()
+			WITH SYSTEM_MODE
 		];
 	}
 }

--- a/force-app/main/default/classes/AsyncActionLoggerTest.cls
+++ b/force-app/main/default/classes/AsyncActionLoggerTest.cls
@@ -64,12 +64,14 @@ private class AsyncActionLoggerTest {
 
 	@IsTest
 	static void shouldPerformDefaultLoggingLogic() {
-		AsyncActionLogger.DefaultLogger logger = (AsyncActionLogger.DefaultLogger) AsyncActionLogger.INSTANCE;
+		// Ensure the default logger is used
+		AsyncActionGlobalSetting__mdt settings = AsyncActionTestUtils.initGlobalSettings();
+		settings.LoggerPlugin__c = null;
 
 		Test.startTest();
 		try {
-			logger?.log(System.LoggingLevel.FINEST, 'Hello world!');
-			logger?.save();
+			AsyncActionLogger.log(System.LoggingLevel.FINEST, 'Hello world!');
+			AsyncActionLogger.save();
 		} catch (Exception error) {
 			Assert.fail('An error was thrown while performing default logging logic: ' + error);
 		}

--- a/force-app/main/default/classes/AsyncActionSchedulableTest.cls
+++ b/force-app/main/default/classes/AsyncActionSchedulableTest.cls
@@ -169,6 +169,8 @@ private class AsyncActionSchedulableTest {
 		return [
 			SELECT ApexClass.Name, JobType, CronTrigger.NextFireTime
 			FROM AsyncApexJob
+			WHERE ApexClass.Name IN (:AsyncActionJob.class.getName(), :AsyncActionSchedulable.class.getName())
+			WITH SYSTEM_MODE
 			LIMIT 50000
 		];
 	}

--- a/force-app/main/default/classes/AsyncActionScheduleEnforcerTest.cls
+++ b/force-app/main/default/classes/AsyncActionScheduleEnforcerTest.cls
@@ -189,6 +189,7 @@ private class AsyncActionScheduleEnforcerTest {
 			WHERE
 				ApexClass.Name = :AsyncActionSchedulable.class.getName()
 				AND Status IN ('Holding', 'Queued', 'Preparing', 'Processing')
+			WITH SYSTEM_MODE
 			ORDER BY CreatedDate ASC
 		];
 	}

--- a/force-app/main/default/classes/AsyncActionScheduledJobUtilsTest.cls
+++ b/force-app/main/default/classes/AsyncActionScheduledJobUtilsTest.cls
@@ -19,6 +19,7 @@ private class AsyncActionScheduledJobUtilsTest {
 			SELECT Id, CronTriggerId, CronTrigger.CronJobDetail.Name, Status
 			FROM AsyncApexJob
 			WHERE CronTrigger.CronJobDetail.Name = :jobName
+			WITH SYSTEM_MODE
 		];
 	}
 

--- a/force-app/main/default/classes/AsyncActionStartTriggerHandlerTest.cls
+++ b/force-app/main/default/classes/AsyncActionStartTriggerHandlerTest.cls
@@ -15,6 +15,7 @@ private class AsyncActionStartTriggerHandlerTest {
 			SELECT Id
 			FROM AsyncApexJob
 			WHERE ApexClass.Name = :AsyncActionJob.class.getName()
+			WITH SYSTEM_MODE
 		];
 		Assert.isFalse(jobs?.isEmpty(), 'Job(s) were not launched');
 	}
@@ -37,6 +38,7 @@ private class AsyncActionStartTriggerHandlerTest {
 			SELECT Id
 			FROM AsyncApexJob
 			WHERE ApexClass.Name = :AsyncActionJob.class.getName()
+			WITH SYSTEM_MODE
 		];
 		Assert.areEqual(1, jobs?.size(), 'Job was not launched');
 	}
@@ -57,6 +59,7 @@ private class AsyncActionStartTriggerHandlerTest {
 			SELECT Id
 			FROM AsyncApexJob
 			WHERE ApexClass.Name = :AsyncActionJob.class.getName()
+			WITH SYSTEM_MODE
 		];
 		Assert.isTrue(jobs?.isEmpty(), 'Job(s) were launched, but not listed in Actions__c');
 	}

--- a/force-app/main/default/classes/AsyncActionTriggerHandlerTest.cls
+++ b/force-app/main/default/classes/AsyncActionTriggerHandlerTest.cls
@@ -12,7 +12,8 @@ private class AsyncActionTriggerHandlerTest {
 		List<AsyncApexJob> jobs = [
 			SELECT Id
 			FROM AsyncApexJob
-			WHERE JobType = 'Queueable'
+			WHERE ApexClass.Name = :AsyncActionJob.class.getName()
+			WITH SYSTEM_MODE
 			LIMIT 1
 		];
 		Assert.isFalse(jobs?.isEmpty(), 'Job(s) were not launched on insert');
@@ -30,7 +31,8 @@ private class AsyncActionTriggerHandlerTest {
 		List<AsyncApexJob> jobs = [
 			SELECT Id
 			FROM AsyncApexJob
-			WHERE JobType = 'Queueable'
+			WHERE ApexClass.Name = :AsyncActionJob.class.getName()
+			WITH SYSTEM_MODE
 			LIMIT 1
 		];
 		Assert.isTrue(jobs?.isEmpty(), 'Job(s) were launched on insert');
@@ -51,6 +53,7 @@ private class AsyncActionTriggerHandlerTest {
 			SELECT Id
 			FROM AsyncApexJob
 			WHERE ApexClass.Name = :AsyncActionSchedulable.class.getName()
+			WITH SYSTEM_MODE
 			LIMIT 1
 		];
 		Assert.isFalse(jobs?.isEmpty(), 'Enabled Scheduled Job was not created');
@@ -70,6 +73,7 @@ private class AsyncActionTriggerHandlerTest {
 			SELECT Id
 			FROM AsyncApexJob
 			WHERE ApexClass.Name = :AsyncActionSchedulable.class.getName()
+			WITH SYSTEM_MODE
 			LIMIT 1
 		];
 		Assert.isTrue(jobs?.isEmpty(), 'Disabled Scheduled Job was created');

--- a/scripts/apex/createTestActions.apex
+++ b/scripts/apex/createTestActions.apex
@@ -2,7 +2,7 @@
 AsyncActionProcessor__mdt leadJob = AsyncActionProcessor__mdt.getInstance('Example_Lead_Convert');
 Lead lead = new Lead(Company = 'Test Company', FirstName = 'John', LastName = 'Doe');
 insert lead;
-LeadStatus status = [SELECT ApiName FROM LeadStatus WHERE IsConverted = true LIMIT 1];
+LeadStatus status = [SELECT ApiName FROM LeadStatus WHERE IsConverted = TRUE LIMIT 1];
 Database.LeadConvert conversionInfo = new Database.LeadConvert();
 conversionInfo.setConvertedStatus(status?.ApiName);
 conversionInfo.setLeadId(lead?.Id);
@@ -12,11 +12,11 @@ AsyncActionProcessor__mdt oppJob = AsyncActionProcessor__mdt.getInstance('Exampl
 Account account = new Account(Name = 'Test Account');
 insert account;
 Opportunity opportunity = new Opportunity(
-    AccountId = account?.Id,
-    Amount = 100,
-    CloseDate = Date.today(),
-    Name = 'Test Opportunity',
-    StageName = 'New'
+	AccountId = account?.Id,
+	Amount = 100,
+	CloseDate = Date.today(),
+	Name = 'Test Opportunity',
+	StageName = 'New'
 );
 insert opportunity;
 AsyncAction__c oppAction = AsyncActions.initAction(oppJob, opportunity);

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -17,7 +17,8 @@
 		"apex-async-actions@1.9.0-1": "04tDn0000006yqdIAA",
 		"apex-async-actions@2.0.0-2": "04tDn0000006yrCIAQ",
 		"apex-async-actions@2.1.0-1": "04tDn0000006zJNIAY",
-		"apex-async-actions@3.0.0-1": "04tDn0000011O1TIAU"
+		"apex-async-actions@3.0.0-1": "04tDn0000011O1TIAU",
+		"apex-async-actions@3.0.1-1": "04tDn0000011O1YIAU"
 	},
 	"packageDirectories": [
 		{

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -25,8 +25,8 @@
 			"definitionFile": "config/project-scratch-def.json",
 			"path": "force-app",
 			"package": "apex-async-actions",
-			"versionName": "ver 3.0.0",
-			"versionNumber": "3.0.0.NEXT",
+			"versionName": "ver 3.0.1",
+			"versionNumber": "3.0.1.NEXT",
 			"versionDescription": ""
 		}
 	],


### PR DESCRIPTION
- Fixed an issue in `AsyncActionLoggerTest` that incorrectly assigns the `AsyncActionLogger.DefaultLogger`. This would only fail in orgs that use a `LoggerPlugin__c`
- Fixed an issue w/`AsyncActionSchedulableTest` that incorrectly asserts that a job was launched. 
  - The query was looking for any/all `Queueable` jobs, and it picked up a queueable job from the Nebula Logger package that was installed in the subscriber org & connected to the package via plugin. 
  - Proactively fixed this issue in other tests that query `AsyncApexJob`, even though it wasn't specifically reported this time