### PR TITLE
Fix: separate stderr from stdout in package version creation step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,16 +178,20 @@ jobs:
                   PACKAGE_ALIAS=$(jq -r '.packageDirectories[] | select(.default == true) | .package' sfdx-project.json)
                   COMMAND="sf package version create --code-coverage --installation-key-bypass --json --package \"$PACKAGE_ALIAS\" --post-install-url \"$WIKI_URL\" --wait 29"
                   echo "$COMMAND"
-                  if RESULT=$(eval "$COMMAND" 2>&1); then
+                  STDERR_OUTPUT=$(mktemp)
+                  if RESULT=$(eval "$COMMAND" 2>"$STDERR_OUTPUT"); then
                     # Success - extract version ID
                     VERSION_ID=$(echo "$RESULT" | jq -r '.result.SubscriberPackageVersionId')
                     echo "Package Version ID: $VERSION_ID"
                     echo "version-id=$VERSION_ID" >> "$GITHUB_OUTPUT"
                     [[ -n "$VERSION_ID" && "$VERSION_ID" != "null" ]] || { echo "ERROR: Invalid version ID"; exit 1; }
                   else
-                    echo "::error::Package creation failed: $RESULT"
+                    echo "::error::Package creation failed:"
+                    cat "$STDERR_OUTPUT"
+                    echo "$RESULT"
                     exit 1
                   fi
+                  rm -f "$STDERR_OUTPUT"
 
             - name: Promote Package Version
               if: ${{ github.event_name == 'push' || inputs.promote-package == true }}


### PR DESCRIPTION
The release workflow's \"Create New Package Version\" step was using `2>&1` to capture both stdout and stderr from the `sf package version create` command into a single variable. When the `--json` flag is used, the sf CLI writes its JSON result to stdout and routes progress/warning messages to stderr. Merging the two caused `jq` to see non-JSON content mixed into the output, resulting in a parse error (`Invalid numeric literal at line 1, column 5`) and an exit code 5 failure.

The fix redirects stderr to a temp file, keeping `$RESULT` as clean JSON for `jq` to parse. On failure, the step now prints both the stderr temp file and the stdout result to give clearer diagnostics before exiting.