### PR TITLE
Feat: Always specify delayInMinutes when enqueueing jobs (#171)

### DIFF
--- a/force-app/main/default/classes/AsyncActionLauncher.cls
+++ b/force-app/main/default/classes/AsyncActionLauncher.cls
@@ -1,10 +1,8 @@
-/**
- * @description Responsible for constructing and launching AsyncActionJob queueables.
- * Its `launch` methods will result in a new queueable job if the provided AsyncActionProcessor__mdt object
- * is active, valid, and has pending AsyncAction__c records associated to it.
- */
+/** @description Responsible for constructing and launching AsyncActionJob queueables. Its `launch` methods will result in a new queueable job if the provided AsyncActionProcessor__mdt is active, valid, and has pending AsyncAction__c records. **/
+// Unlocked package public API requires global visibility for external subscriber access
 @SuppressWarnings('PMD.AvoidGlobalModifier')
 global without sharing class AsyncActionLauncher {
+	// **** PUBLIC **** //
 	/**
 	 * @description Launches AsyncActionJob queueables for each processor that has pending actions.
 	 * @param settingsList List of processor configurations to check for pending actions
@@ -46,8 +44,7 @@ global without sharing class AsyncActionLauncher {
 	 * @return A QueueableDuplicateSignature based on the processor's developer name
 	 */
 	private System.QueueableDuplicateSignature buildDuplicateSignature(AsyncActionProcessor__mdt settings) {
-		// Build a QueueableDuplicateSigntuare to prevent launching duplicate Queueable jobs
-		// Note: Max size of QueueableDuplicateSignature is 32 bytes; hash the processor value to prevent exceeding this value
+		// Max size of QueueableDuplicateSignature is 32 bytes; hash the processor name to stay within that limit
 		Blob hashBlob = Crypto.generateDigest('SHA-256', Blob.valueOf(settings?.DeveloperName));
 		String hashHex = EncodingUtil.convertToHex(hashBlob);
 		String hashedSignature = hashHex?.substring(0, 32);
@@ -60,7 +57,6 @@ global without sharing class AsyncActionLauncher {
 	 * @return Set of developer names from the processor configurations
 	 */
 	private Set<String> extractDeveloperNamesFrom(List<AsyncActionProcessor__mdt> settingsList) {
-		// Extract the DeveloperName from the
 		Set<String> results = new Set<String>{};
 		for (AsyncActionProcessor__mdt settings : settingsList) {
 			String developerName = settings?.DeveloperName;
@@ -77,11 +73,14 @@ global without sharing class AsyncActionLauncher {
 	 */
 	@TestVisible
 	private Integer getDelayInMinutes(AsyncActionProcessor__mdt settings) {
+		Integer delay;
 		if (settings?.DelayInMinutes__c != null) {
-			return settings.DelayInMinutes__c.intValue();
+			delay = settings.DelayInMinutes__c.intValue();
+		} else {
+			AsyncActionGlobalSetting__mdt globalSettings = AsyncActionGlobalSettingService.getSettings();
+			delay = (globalSettings?.DelayInMinutes__c)?.intValue() ?? 0;
 		}
-		AsyncActionGlobalSetting__mdt globalSettings = AsyncActionGlobalSettingService.getSettings();
-		return (globalSettings?.DelayInMinutes__c)?.intValue() ?? 0;
+		return delay;
 	}
 
 	/**
@@ -90,8 +89,7 @@ global without sharing class AsyncActionLauncher {
 	 * @return Maximum stack depth value, defaults to 5 if not specified
 	 */
 	private Integer getMaxStackDepth(AsyncActionProcessor__mdt settings) {
-		// Returns the maximum stack depth value defined in the settings
-		// Defaults to 5 if none found; this matches the current Queueable defaults
+		// Defaults to 5 to match the Salesforce Queueable platform default
 		return (settings?.MaxStackDepth__c)?.intValue() ?? 5;
 	}
 
@@ -101,13 +99,11 @@ global without sharing class AsyncActionLauncher {
 	 * @return Configured AsyncOptions with duplicate signature, stack depth, and delay
 	 */
 	private System.AsyncOptions initAsyncOptions(AsyncActionProcessor__mdt settings) {
-		// This method defines the AsyncOptions used to enqueue an AsyncActionJob
 		System.AsyncOptions options = new System.AsyncOptions();
-		// Use QueueableDuplicateSignature to prevent multiple instances of the same processor job
+		// DuplicateSignature prevents multiple instances of the same processor from running concurrently
 		options.DuplicateSignature = this.buildDuplicateSignature(settings);
-		// Set a stack depth using the value defined in the job settings
 		options.MaximumQueueableStackDepth = this.getMaxStackDepth(settings);
-		// Always specify a delay to avoid being affected by org-wide default delay settings
+		// Always specify a delay to avoid being buffered by org-wide default delay settings
 		options.minimumQueueableDelayInMinutes = this.getDelayInMinutes(settings);
 		return options;
 	}
@@ -118,18 +114,14 @@ global without sharing class AsyncActionLauncher {
 	 * @return ID of the launched job, or null if launch failed
 	 */
 	private Id launchJobToProcess(String processorName) {
-		// The main/underlying processing method; attempts to launch an AsyncActionJob for the specified processor
 		try {
 			AsyncActionProcessor__mdt settings = AsyncActionProcessorService.get(processorName);
-			// Check that the job is active & valid, and that a queueable can be launched
 			this.validateQueueableLimits();
 			this.validateProcessorSettings(settings);
-			// Construct and launch the job
 			System.AsyncOptions options = this.initAsyncOptions(settings);
 			AsyncActionLauncher.Factory factory = new AsyncActionLauncher.Factory(settings);
 			AsyncActionJob job = new AsyncActionJob(factory);
 			Id jobId = System.enqueueJob(job, options);
-			// Inspect and return the resulting jobId
 			AsyncActionLogger.log(System.LoggingLevel.FINEST, processorName + ': launch() -> ' + jobId);
 			return jobId;
 		} catch (Exception error) {
@@ -145,7 +137,6 @@ global without sharing class AsyncActionLauncher {
 	 * @return List of PendingAction objects representing processors with pending work
 	 */
 	private List<PendingAction> queryPendingActions(List<AsyncActionProcessor__mdt> settingsList) {
-		// Retrieves a list of processors w/open actions, in FIFO order
 		List<AggregateResult> results = [
 			SELECT ProcessorName__c processorName
 			FROM AsyncAction__c
@@ -158,8 +149,8 @@ global without sharing class AsyncActionLauncher {
 			HAVING COUNT(Id) > 0
 			ORDER BY MAX(NextEligibleAt__c) ASC // first in, first out!
 		];
-		// Convert & return the query results in a common format
-		return (List<PendingAction>) JSON.deserialize(JSON.serialize(results), List<PendingAction>.class);
+		String serialized = JSON.serialize(results);
+		return (List<PendingAction>) JSON.deserialize(serialized, List<PendingAction>.class);
 	}
 
 	/**
@@ -167,31 +158,22 @@ global without sharing class AsyncActionLauncher {
 	 * @param settings The processor configuration to validate
 	 */
 	private void validateProcessorSettings(AsyncActionProcessor__mdt settings) {
-		// Throws an exception if the current job is disabled
 		if (settings?.Enabled__c != true) {
 			throw new System.AsyncException(settings?.DeveloperName + ' is disabled');
 		}
 	}
 
-	/**
-	 * @description Validates that queueable job limits have not been reached
-	 */
+	/** @description Validates that queueable job limits have not been reached **/
 	private void validateQueueableLimits() {
-		// Throws an exception if Queueable limits have been reached
 		if (Limits.getQueueableJobs() >= Limits.getLimitQueueableJobs()) {
 			throw new System.AsyncException('Reached Queueable job limit: ' + Limits.getQueueableJobs());
 		}
 	}
 
 	// **** INNER **** //
-	/**
-	 * @description Factory class used to construct AsyncActionJob instances.
-	 * This pattern forces callers to use the `launch` methods to create & launch jobs.
-	 */
+	/** @description Factory class used to construct AsyncActionJob instances. Callers must use the `launch` methods rather than constructing jobs directly. **/
 	public class Factory {
-		/**
-		 * @description The processor settings associated with this factory
-		 */
+		/** @description The processor settings associated with this factory **/
 		private AsyncActionProcessor__mdt settings;
 
 		/**
@@ -212,14 +194,9 @@ global without sharing class AsyncActionLauncher {
 		}
 	}
 
-	/**
-	 * @description Used to store aggregate query results for processors with pending actions.
-	 * Its `processorName` points to an AsyncActionProcessor__mdt with related/open Async Actions.
-	 */
+	/** @description Wraps aggregate query results for processors with pending actions. Its `processorName` maps to an AsyncActionProcessor__mdt with open AsyncAction__c records. **/
 	private class PendingAction {
-		/**
-		 * @description Name of the processor that has pending actions
-		 */
+		/** @description Name of the processor that has pending actions **/
 		public String processorName { get; private set; }
 	}
 }

--- a/force-app/main/default/classes/AsyncActionLauncher.cls
+++ b/force-app/main/default/classes/AsyncActionLauncher.cls
@@ -70,6 +70,21 @@ global without sharing class AsyncActionLauncher {
 	}
 
 	/**
+	 * @description Gets the delay in minutes before enqueueing a job for the given processor.
+	 * Processor-level setting takes priority over global setting; defaults to 0.
+	 * @param settings The processor configuration to check for delay setting
+	 * @return Delay in minutes to use when enqueueing the job
+	 */
+	@TestVisible
+	private Integer getDelayInMinutes(AsyncActionProcessor__mdt settings) {
+		if (settings?.DelayInMinutes__c != null) {
+			return settings.DelayInMinutes__c.intValue();
+		}
+		AsyncActionGlobalSetting__mdt globalSettings = AsyncActionGlobalSettingService.getSettings();
+		return (globalSettings?.DelayInMinutes__c)?.intValue() ?? 0;
+	}
+
+	/**
 	 * @description Gets the maximum stack depth value from processor settings
 	 * @param settings The processor configuration containing stack depth setting
 	 * @return Maximum stack depth value, defaults to 5 if not specified
@@ -83,7 +98,7 @@ global without sharing class AsyncActionLauncher {
 	/**
 	 * @description Initializes AsyncOptions for enqueueing AsyncActionJob
 	 * @param settings The processor configuration to configure async options for
-	 * @return Configured AsyncOptions with duplicate signature and stack depth
+	 * @return Configured AsyncOptions with duplicate signature, stack depth, and delay
 	 */
 	private System.AsyncOptions initAsyncOptions(AsyncActionProcessor__mdt settings) {
 		// This method defines the AsyncOptions used to enqueue an AsyncActionJob
@@ -92,6 +107,8 @@ global without sharing class AsyncActionLauncher {
 		options.DuplicateSignature = this.buildDuplicateSignature(settings);
 		// Set a stack depth using the value defined in the job settings
 		options.MaximumQueueableStackDepth = this.getMaxStackDepth(settings);
+		// Always specify a delay to avoid being affected by org-wide default delay settings
+		options.minimumQueueableDelayInMinutes = this.getDelayInMinutes(settings);
 		return options;
 	}
 

--- a/force-app/main/default/classes/AsyncActionLauncher.cls
+++ b/force-app/main/default/classes/AsyncActionLauncher.cls
@@ -73,14 +73,8 @@ global without sharing class AsyncActionLauncher {
 	 */
 	@TestVisible
 	private Integer getDelayInMinutes(AsyncActionProcessor__mdt settings) {
-		Integer delay;
-		if (settings?.DelayInMinutes__c != null) {
-			delay = settings.DelayInMinutes__c.intValue();
-		} else {
-			AsyncActionGlobalSetting__mdt globalSettings = AsyncActionGlobalSettingService.getSettings();
-			delay = (globalSettings?.DelayInMinutes__c)?.intValue() ?? 0;
-		}
-		return delay;
+		Decimal delay = settings?.DelayInMinutes__c ?? AsyncActionGlobalSettingService.getSettings()?.DelayInMinutes__c;
+		return delay?.intValue() ?? 0;
 	}
 
 	/**

--- a/force-app/main/default/classes/AsyncActionLauncherTest.cls
+++ b/force-app/main/default/classes/AsyncActionLauncherTest.cls
@@ -114,6 +114,48 @@ private class AsyncActionLauncherTest {
 		Assert.isNull(jobId2, 'Duplicate job was launched');
 	}
 
+	@IsTest
+	static void shouldDefaultToZeroDelay() {
+		AsyncActionProcessor__mdt settings = AsyncActionTestUtils.initApexProcessor(MockAsyncActionProcessor.class);
+		// No DelayInMinutes__c set on processor or global settings
+
+		Test.startTest();
+		Integer delay = new AsyncActionLauncher().getDelayInMinutes(settings);
+		Test.stopTest();
+
+		Assert.areEqual(0, delay, 'Expected default delay of 0');
+	}
+
+	@IsTest
+	static void shouldUseProcessorLevelDelay() {
+		AsyncActionProcessor__mdt settings = AsyncActionTestUtils.initApexProcessor(MockAsyncActionProcessor.class);
+		settings.DelayInMinutes__c = 5;
+		AsyncActionGlobalSetting__mdt globalSettings = AsyncActionTestUtils.initGlobalSettings();
+		globalSettings.DelayInMinutes__c = 10;
+		AsyncActionTestUtils.mockGlobalSettings(globalSettings);
+
+		Test.startTest();
+		Integer delay = new AsyncActionLauncher().getDelayInMinutes(settings);
+		Test.stopTest();
+
+		Assert.areEqual(5, delay, 'Expected processor-level delay of 5, not global');
+	}
+
+	@IsTest
+	static void shouldFallBackToGlobalDelay() {
+		AsyncActionProcessor__mdt settings = AsyncActionTestUtils.initApexProcessor(MockAsyncActionProcessor.class);
+		// No processor-level DelayInMinutes__c
+		AsyncActionGlobalSetting__mdt globalSettings = AsyncActionTestUtils.initGlobalSettings();
+		globalSettings.DelayInMinutes__c = 3;
+		AsyncActionTestUtils.mockGlobalSettings(globalSettings);
+
+		Test.startTest();
+		Integer delay = new AsyncActionLauncher().getDelayInMinutes(settings);
+		Test.stopTest();
+
+		Assert.areEqual(3, delay, 'Expected global-level delay of 3');
+	}
+
 	// **** HELPER **** //
 	private static Integer getNumAsyncJobs() {
 		return [

--- a/force-app/main/default/classes/AsyncActionLauncherTest.cls
+++ b/force-app/main/default/classes/AsyncActionLauncherTest.cls
@@ -1,3 +1,4 @@
+/** @description Tests for AsyncActionLauncher covering launch conditions, duplicate prevention, and delay resolution **/
 @SuppressWarnings('PMD.ApexUnitTestClassShouldHaveRunAs')
 @IsTest
 private class AsyncActionLauncherTest {
@@ -33,7 +34,7 @@ private class AsyncActionLauncherTest {
 
 	@IsTest
 	static void shouldNotLaunchInvalidJob() {
-		Type fakeProcessorType = Account.class; // Obv not a real processor!
+		Type fakeProcessorType = Account.class;
 		AsyncActionTestUtils.initScheduledJobSettings();
 		AsyncActionProcessor__mdt settings = AsyncActionTestUtils.initApexProcessor(fakeProcessorType);
 		AsyncAction__c action = AsyncActions.initAction(settings);
@@ -71,13 +72,11 @@ private class AsyncActionLauncherTest {
 		Database.insert(action, System.AccessLevel.SYSTEM_MODE);
 
 		Test.startTest();
-		// Spin up a bunch of queueable jobs, until the limit is met
 		AsyncActionLauncher.Factory factory = new AsyncActionLauncher.Factory(settings);
 		for (Integer i = 0; i < Limits.getLimitQueueableJobs(); i++) {
 			AsyncActionJob job = new AsyncActionJob(factory);
 			System.enqueueJob(job);
 		}
-		// NOW try to launch the job
 		Id jobId = new AsyncActionLauncher()?.launch(settings);
 		Test.stopTest();
 
@@ -117,7 +116,6 @@ private class AsyncActionLauncherTest {
 	@IsTest
 	static void shouldDefaultToZeroDelay() {
 		AsyncActionProcessor__mdt settings = AsyncActionTestUtils.initApexProcessor(MockAsyncActionProcessor.class);
-		// No DelayInMinutes__c set on processor or global settings
 
 		Test.startTest();
 		Integer delay = new AsyncActionLauncher().getDelayInMinutes(settings);
@@ -144,7 +142,6 @@ private class AsyncActionLauncherTest {
 	@IsTest
 	static void shouldFallBackToGlobalDelay() {
 		AsyncActionProcessor__mdt settings = AsyncActionTestUtils.initApexProcessor(MockAsyncActionProcessor.class);
-		// No processor-level DelayInMinutes__c
 		AsyncActionGlobalSetting__mdt globalSettings = AsyncActionTestUtils.initGlobalSettings();
 		globalSettings.DelayInMinutes__c = 3;
 		AsyncActionTestUtils.mockGlobalSettings(globalSettings);
@@ -156,7 +153,7 @@ private class AsyncActionLauncherTest {
 		Assert.areEqual(3, delay, 'Expected global-level delay of 3');
 	}
 
-	// **** HELPER **** //
+	// **** PRIVATE **** //
 	private static Integer getNumAsyncJobs() {
 		return [
 			SELECT COUNT()

--- a/force-app/main/default/objects/AsyncActionGlobalSetting__mdt/fields/DelayInMinutes__c.field-meta.xml
+++ b/force-app/main/default/objects/AsyncActionGlobalSetting__mdt/fields/DelayInMinutes__c.field-meta.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>DelayInMinutes__c</fullName>
+    <externalId>false</externalId>
+    <fieldManageability>SubscriberControlled</fieldManageability>
+    <inlineHelpText>The default number of minutes to delay before enqueueing new jobs across all processors.
+Individual processors may override this via AsyncActionProcessor__mdt.DelayInMinutes__c.
+Set to 0 to enqueue immediately, bypassing any org-wide default delay.
+When left blank, defaults to 0.</inlineHelpText>
+    <label>Delay (Minutes)</label>
+    <precision>18</precision>
+    <required>false</required>
+    <scale>0</scale>
+    <type>Number</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/AsyncActionProcessor__mdt/fields/DelayInMinutes__c.field-meta.xml
+++ b/force-app/main/default/objects/AsyncActionProcessor__mdt/fields/DelayInMinutes__c.field-meta.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>DelayInMinutes__c</fullName>
+    <externalId>false</externalId>
+    <fieldManageability>SubscriberControlled</fieldManageability>
+    <inlineHelpText>The number of minutes to delay before enqueueing a new job for this processor.
+When left blank, falls back to the value defined in AsyncActionGlobalSetting__mdt.
+Set to 0 to enqueue immediately, bypassing any org-wide default delay.</inlineHelpText>
+    <label>Delay (Minutes)</label>
+    <precision>18</precision>
+    <required>false</required>
+    <scale>0</scale>
+    <type>Number</type>
+    <unique>false</unique>
+</CustomField>

--- a/wiki/The-AsyncActionGlobalSetting__mdt-Custom-Metadata-Type.md
+++ b/wiki/The-AsyncActionGlobalSetting__mdt-Custom-Metadata-Type.md
@@ -2,11 +2,12 @@ The `AsyncActionGlobalSetting__mdt` custom metadata type defines package-wide be
 
 ## Field Reference
 
-| Field API Name    | Label         | Data Type | Required | Default | Description                                          |
-| ----------------- | ------------- | --------- | -------- | ------- | ---------------------------------------------------- |
-| `DeveloperName`   | API Name      | Text(40)  | Yes      | -       | Unique identifier for the global settings            |
-| `MasterLabel`     | Label         | Text(40)  | Yes      | -       | Human-readable name for the settings                 |
-| `LoggerPlugin__c` | Logger Plugin | Text(255) | No       | -       | Fully qualified name of custom logger implementation |
+| Field API Name      | Label            | Data Type   | Required | Default | Description                                          |
+| ------------------- | ---------------- | ----------- | -------- | ------- | ---------------------------------------------------- |
+| `DeveloperName`     | API Name         | Text(40)    | Yes      | -       | Unique identifier for the global settings            |
+| `MasterLabel`       | Label            | Text(40)    | Yes      | -       | Human-readable name for the settings                 |
+| `LoggerPlugin__c`   | Logger Plugin    | Text(255)   | No       | -       | Fully qualified name of custom logger implementation |
+| `DelayInMinutes__c` | Delay In Minutes | Number(2,0) | No       | 0       | Default delay in minutes before enqueueing jobs      |
 
 ## Configuration
 

--- a/wiki/The-AsyncActionGlobalSetting__mdt-Custom-Metadata-Type.md
+++ b/wiki/The-AsyncActionGlobalSetting__mdt-Custom-Metadata-Type.md
@@ -1,19 +1,53 @@
 The `AsyncActionGlobalSetting__mdt` custom metadata type defines package-wide behavior for the async actions framework. It controls global settings that affect all processors and framework operations.
 
+Async Action Global Setting records establish framework defaults that apply across all processors. These settings provide centralized control over logging and execution timing.
+
+## Purpose and Usage
+
+Async Action Global Setting records define:
+
+1. **Logging Configuration** - Custom logger implementation for framework-wide logging
+2. **Default Delay Settings** - Global default for queueable job delays across all processors
+3. **Framework Behavior** - Controls that affect all async action processing
+
 ## Field Reference
 
-| Field API Name      | Label            | Data Type   | Required | Default | Description                                          |
-| ------------------- | ---------------- | ----------- | -------- | ------- | ---------------------------------------------------- |
-| `DeveloperName`     | API Name         | Text(40)    | Yes      | -       | Unique identifier for the global settings            |
-| `MasterLabel`       | Label            | Text(40)    | Yes      | -       | Human-readable name for the settings                 |
-| `LoggerPlugin__c`   | Logger Plugin    | Text(255)   | No       | -       | Fully qualified name of custom logger implementation |
-| `DelayInMinutes__c` | Delay In Minutes | Number(2,0) | No       | 0       | Default delay in minutes before enqueueing jobs      |
+| Field API Name      | Label            | Data Type   | Required | Default | Description                                                                                                                    |
+| ------------------- | ---------------- | ----------- | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `DeveloperName`     | API Name         | Text(40)    | Yes      | -       | Unique identifier for the global settings                                                                                      |
+| `MasterLabel`       | Label            | Text(40)    | Yes      | -       | Human-readable name for the settings                                                                                           |
+| `LoggerPlugin__c`   | Logger Plugin    | Text(255)   | No       | -       | Fully qualified name of custom logger implementation that implements AsyncActionLogger.Adapter                                 |
+| `DelayInMinutes__c` | Delay (Minutes)  | Number(18,0) | No       | 0       | Default number of minutes to delay before enqueueing new jobs across all processors. Individual processors may override this. |
 
 ## Configuration
 
 1. Navigate to **Setup → Custom Metadata Types → Async Action Global Setting → Manage Records**
 2. Create or edit the global settings record
-3. Set the **Logger Plugin** field to your custom logger class name
-4. Save the record
+3. Set the **Logger Plugin** field to your custom logger class name (must implement `AsyncActionLogger.Adapter`)
+4. Set the **Delay (Minutes)** field to control default queueable delay timing (set to 0 for immediate execution)
+5. Save the record
 
-Note: If no Async Action Global Setting record exists or no logger plugin is specified, the framework uses `System.debug()` for all logging.
+**Note**: If no Async Action Global Setting record exists or no logger plugin is specified, the framework uses `System.debug()` for all logging.
+
+## Delay Configuration
+
+The `DelayInMinutes__c` field controls how long the framework waits before enqueueing queueable jobs. This setting addresses scenarios where orgs have configured org-wide default delays for queueable jobs:
+
+- **Default**: `0` (no delay - immediate execution)
+- **Override**: Individual processors can override this via `AsyncActionProcessor__mdt.DelayInMinutes__c`
+- **Purpose**: Ensures the framework controls its own timing instead of inheriting org-wide defaults
+
+When set to `0`, the framework explicitly requests immediate execution, bypassing any org-wide default delay settings.
+
+## Best Practices
+
+- **Logger Implementation** - Use a custom logger that implements the `AsyncActionLogger.Adapter` interface for production monitoring
+- **Delay Configuration** - Set to `0` unless you have a specific need to delay all async processing
+- **Single Record** - Only one global settings record should exist per org
+
+## Related Objects
+
+- [AsyncActionProcessor\_\_mdt](./The-AsyncActionProcessor__mdt-Custom-Metadata-Type) - Processor-specific configurations that can override global settings
+- [AsyncAction\_\_c](./The-AsyncAction__c-Object) - Records processed according to these global settings
+
+---

--- a/wiki/The-AsyncActionProcessor__mdt-Custom-Metadata-Type.md
+++ b/wiki/The-AsyncActionProcessor__mdt-Custom-Metadata-Type.md
@@ -30,6 +30,19 @@ Async Action Processor records define:
 | `Data__c`           | Data             | Long Text Area | No       | -       | Custom configuration data for the processor                         |
 | `Description__c`    | Description      | Long Text Area | No       | -       | Documentation about the processor's purpose                         |
 
+## Delay Configuration
+
+The `DelayInMinutes__c` field controls the delay before enqueueing queueable jobs for this specific processor:
+
+- **Default**: When blank, inherits the value from `AsyncActionGlobalSetting__mdt.DelayInMinutes__c`
+- **Override**: Set to `0` for immediate execution, or a specific number of minutes to delay
+- **Purpose**: Ensures the processor controls its own timing instead of inheriting org-wide defaults
+
+This setting is particularly useful when:
+- Your org has configured org-wide default delays for queueable jobs
+- You need different timing behavior for different processors
+- You want to prioritize certain processors over others
+
 ## Best Practices
 
 -   **Start with larger batch sizes (200+)** - Begin with higher batch sizes and adjust based on processing requirements
@@ -38,6 +51,7 @@ Async Action Processor records define:
 -   **Consider Complexity** - Reduce batch size for processor-intensive operations
 -   **Appropriate Retries** - Set retry counts based on expected failure patterns
 -   **Reasonable Intervals** - Allow enough time for transient issues to resolve
+-   **Delay Configuration** - Set to `0` for time-sensitive processors, or use a delay for lower-priority background work
 
 ## Related Objects
 

--- a/wiki/The-AsyncActionProcessor__mdt-Custom-Metadata-Type.md
+++ b/wiki/The-AsyncActionProcessor__mdt-Custom-Metadata-Type.md
@@ -14,20 +14,21 @@ Async Action Processor records define:
 
 ## Field Reference
 
-| Field API Name     | Label           | Data Type      | Required | Default | Description                                            |
-| ------------------ | --------------- | -------------- | -------- | ------- | ------------------------------------------------------ | ------------------------- |
-| `DeveloperName`    | API Name        | Text(40)       | Yes      | -       | Unique identifier for the processor configuration      |
-| `MasterLabel`      | Label           | Text(40)       | Yes      | -       | Human-readable name for the processor                  |
-| `Processor__c`     | Processor       | Text(255)      | Yes      | -       | Fully qualified name of the Apex class or Flow         |
-| `ProcessorType__c` | Processor Type  | Picklist       | Yes      | Apex    | Whether the processor is implemented in Apex or Flow   |
-| `Enabled__c`       | Enabled         | Checkbox       | No       | true    | Controls whether this processor can execute            |
-| `BatchSize__c`     | Batch Size      | Number(18,0)   | Yes      | 200     | Number of AsyncAction records to process per execution |
-| `Retries__c`       | Retries         | Number(18,0)   | No       | 0       | Default number of retry attempts for new actions       |
-| `RetryInterval__c` | Retry Interval  | Number(18,0)   | No       | 5       | Minutes to wait between retry attempts                 |
-| `RunOnInsert__c`   | Run On Insert   | Checkbox       | No       | false   | Whether to automatically process actions when inserted |
-| `MaxStackDepth__c` | Max Stack Depth | Number(18,0)   | No       | 1       | Maximum recursion depth for chained processing         |
-| `Data__c`          | Data            | Long Text Area | No       | -       | Custom configuration data for the processor            |
-| `Description__c`   | Description     | Long Text Area | No       | -       | Documentation about the processor's purpose            | Operational documentation |
+| Field API Name      | Label            | Data Type      | Required | Default | Description                                                         |
+| ------------------- | ---------------- | -------------- | -------- | ------- | ------------------------------------------------------------------- |
+| `DeveloperName`     | API Name         | Text(40)       | Yes      | -       | Unique identifier for the processor configuration                   |
+| `MasterLabel`       | Label            | Text(40)       | Yes      | -       | Human-readable name for the processor                               |
+| `Processor__c`      | Processor        | Text(255)      | Yes      | -       | Fully qualified name of the Apex class or Flow                      |
+| `ProcessorType__c`  | Processor Type   | Picklist       | Yes      | Apex    | Whether the processor is implemented in Apex or Flow                |
+| `Enabled__c`        | Enabled          | Checkbox       | No       | true    | Controls whether this processor can execute                         |
+| `BatchSize__c`      | Batch Size       | Number(18,0)   | Yes      | 200     | Number of AsyncAction records to process per execution              |
+| `Retries__c`        | Retries          | Number(18,0)   | No       | 0       | Default number of retry attempts for new actions                    |
+| `RetryInterval__c`  | Retry Interval   | Number(18,0)   | No       | 5       | Minutes to wait between retry attempts                              |
+| `RunOnInsert__c`    | Run On Insert    | Checkbox       | No       | false   | Whether to automatically process actions when inserted              |
+| `MaxStackDepth__c`  | Max Stack Depth  | Number(18,0)   | No       | 1       | Maximum recursion depth for chained processing                      |
+| `DelayInMinutes__c` | Delay In Minutes | Number(2,0)    | No       | -       | Override delay in minutes before enqueueing jobs (overrides global) |
+| `Data__c`           | Data             | Long Text Area | No       | -       | Custom configuration data for the processor                         |
+| `Description__c`    | Description      | Long Text Area | No       | -       | Documentation about the processor's purpose                         |
 
 ## Best Practices
 


### PR DESCRIPTION
**Closes #171**. Salesforce introduced an org-wide default delay setting for queueable jobs, which allows admins to slow execution across all queueables that don't explicitly specify a delay. Because `AsyncActionLauncher` was calling `System.enqueueJob(job, options)` without setting a delay value, any org with this setting enabled would unintentionally buffer async actions — undermining the framework's expectation of near-immediate execution.

The fix sets `options.minimumQueueableDelayInMinutes` on the `AsyncOptions` object before enqueueing, ensuring the framework always controls its own timing. The default is `0` (no delay), but users can now configure delays at two levels: a global default via `AsyncActionGlobalSetting__mdt.DelayInMinutes__c`, or a per-processor override via `AsyncActionProcessor__mdt.DelayInMinutes__c`. The processor-level setting takes priority over the global one, and both fall back to `0` when unset.