### PR TITLE
Fix: Test isolation failures in orgs with live scheduled jobs

### DIFF
--- a/force-app/main/default/classes/AsyncActionSchedulableTest.cls
+++ b/force-app/main/default/classes/AsyncActionSchedulableTest.cls
@@ -121,11 +121,16 @@ private class AsyncActionSchedulableTest {
 	}
 
 	static Map<String, AsyncApexJob> getAsyncJobs() {
+		String schedulableJobName = AsyncActionScheduledJobUtils.getJobName(jobSettings);
 		Map<String, AsyncApexJob> jobsByClassName = new Map<String, AsyncApexJob>{};
 		for (AsyncApexJob job : [
 			SELECT ApexClass.Name, JobType, CronTrigger.NextFireTime
 			FROM AsyncApexJob
-			WHERE ApexClass.Name IN (:AsyncActionJob.class.getName(), :AsyncActionSchedulable.class.getName())
+			WHERE
+				ApexClass.Name = :AsyncActionJob.class.getName()
+				OR (ApexClass.Name = :AsyncActionSchedulable.class.getName()
+				AND CronTrigger.CronJobDetail.Name = :schedulableJobName
+				AND Status = 'Queued')
 			WITH SYSTEM_MODE
 			LIMIT 50000
 		]) {

--- a/force-app/main/default/classes/AsyncActionTriggerHandlerTest.cls
+++ b/force-app/main/default/classes/AsyncActionTriggerHandlerTest.cls
@@ -50,18 +50,10 @@ private class AsyncActionTriggerHandlerTest {
 		Database.insert(action, System.AccessLevel.SYSTEM_MODE);
 		Test.getEventBus().deliver();
 
-		String expectedJobName = AsyncActionScheduledJobUtils.getJobName(jobSettings);
-		List<AsyncApexJob> jobs = [
-			SELECT Id
-			FROM AsyncApexJob
-			WHERE
-				ApexClass.Name = :AsyncActionSchedulable.class.getName()
-				AND CronTrigger.CronJobDetail.Name = :expectedJobName
-				AND Status = 'Queued'
-			WITH SYSTEM_MODE
-			LIMIT 1
-		];
-		Assert.isFalse(jobs?.isEmpty(), 'Enabled Scheduled Job was not created');
+		Assert.isFalse(
+			AsyncActionTriggerHandlerTest.getScheduledJobs(jobSettings)?.isEmpty(),
+			'Enabled Scheduled Job was not created'
+		);
 	}
 
 	@IsTest
@@ -74,18 +66,10 @@ private class AsyncActionTriggerHandlerTest {
 		Database.insert(action, System.AccessLevel.SYSTEM_MODE);
 		Test.getEventBus().deliver();
 
-		String expectedJobName = AsyncActionScheduledJobUtils.getJobName(jobSettings);
-		List<AsyncApexJob> jobs = [
-			SELECT Id
-			FROM AsyncApexJob
-			WHERE
-				ApexClass.Name = :AsyncActionSchedulable.class.getName()
-				AND CronTrigger.CronJobDetail.Name = :expectedJobName
-				AND Status = 'Queued'
-			WITH SYSTEM_MODE
-			LIMIT 1
-		];
-		Assert.isTrue(jobs?.isEmpty(), 'Disabled Scheduled Job was created');
+		Assert.isTrue(
+			AsyncActionTriggerHandlerTest.getScheduledJobs(jobSettings)?.isEmpty(),
+			'Disabled Scheduled Job was created'
+		);
 	}
 
 	@IsTest
@@ -130,5 +114,20 @@ private class AsyncActionTriggerHandlerTest {
 
 		action = [SELECT Id, Retries__c FROM AsyncAction__c WHERE Id = :action.Id];
 		Assert.areEqual(3, action?.Retries__c, 'Wrong # of Retries');
+	}
+
+	// **** HELPER **** //
+	static List<AsyncApexJob> getScheduledJobs(AsyncActionScheduledJob__mdt jobSettings) {
+		String expectedJobName = AsyncActionScheduledJobUtils.getJobName(jobSettings);
+		return [
+			SELECT Id
+			FROM AsyncApexJob
+			WHERE
+				ApexClass.Name = :AsyncActionSchedulable.class.getName()
+				AND CronTrigger.CronJobDetail.Name = :expectedJobName
+				AND Status = 'Queued'
+			WITH SYSTEM_MODE
+			LIMIT 1
+		];
 	}
 }

--- a/force-app/main/default/classes/AsyncActionTriggerHandlerTest.cls
+++ b/force-app/main/default/classes/AsyncActionTriggerHandlerTest.cls
@@ -50,10 +50,14 @@ private class AsyncActionTriggerHandlerTest {
 		Database.insert(action, System.AccessLevel.SYSTEM_MODE);
 		Test.getEventBus().deliver();
 
+		String expectedJobName = AsyncActionScheduledJobUtils.getJobName(jobSettings);
 		List<AsyncApexJob> jobs = [
 			SELECT Id
 			FROM AsyncApexJob
-			WHERE ApexClass.Name = :AsyncActionSchedulable.class.getName()
+			WHERE
+				ApexClass.Name = :AsyncActionSchedulable.class.getName()
+				AND CronTrigger.CronJobDetail.Name = :expectedJobName
+				AND Status = 'Queued'
 			WITH SYSTEM_MODE
 			LIMIT 1
 		];
@@ -70,10 +74,14 @@ private class AsyncActionTriggerHandlerTest {
 		Database.insert(action, System.AccessLevel.SYSTEM_MODE);
 		Test.getEventBus().deliver();
 
+		String expectedJobName = AsyncActionScheduledJobUtils.getJobName(jobSettings);
 		List<AsyncApexJob> jobs = [
 			SELECT Id
 			FROM AsyncApexJob
-			WHERE ApexClass.Name = :AsyncActionSchedulable.class.getName()
+			WHERE
+				ApexClass.Name = :AsyncActionSchedulable.class.getName()
+				AND CronTrigger.CronJobDetail.Name = :expectedJobName
+				AND Status = 'Queued'
 			WITH SYSTEM_MODE
 			LIMIT 1
 		];


### PR DESCRIPTION
When these tests are run in an org that has live scheduled jobs (rather than a clean scratch org), `AsyncApexJob` SOQL returns real org data — including the org's historical Aborted and Failed records as well as its currently Queued scheduled jobs. Because the `AsyncActionSchedulable` test helpers queried by class name alone with no status or name filter, this live org data contaminated test assertions: disabled-job tests that expected an empty result would find the org's existing jobs and fail, while enabled-job tests would have their `CronTrigger.NextFireTime` overwritten by a historical Aborted record (which has no live CronTrigger) resulting in a null value.

The fix adds two filters to every `AsyncApexJob` query that checks for scheduled jobs: a `Status = 'Queued'` filter to exclude historical Aborted/Failed records, and a `CronTrigger.CronJobDetail.Name` filter scoped to the specific job name the test created. Both are necessary — the status filter alone still leaves the org's live Queued jobs in scope, and only the name filter provides true isolation by restricting results to jobs the test itself scheduled.